### PR TITLE
Add `phpcs-baseline` command for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ to the root of the project and name it `phpcs.baseline.xml`.
 ```bash
 php vendor/bin/phpcs src tests --report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline --report-file=phpcs.baseline.xml --basepath=.
 ```
+Or convenient wrapper for the above command:
+```bash
+php vendor/bin/phpcs-baseline src tests
+```
 
 ## Usage
 Use phpcs like you normally would. With `phpcs.baseline.xml` in the root of your project, the baseline extension will automatically read the config 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ php vendor/bin/phpcs src tests --report=\\DR\\CodeSnifferBaseline\\Reports\\Base
 ```
 Or convenient wrapper for the above command:
 ```bash
-php vendor/bin/phpcs-baseline src tests
+php vendor/bin/phpcs-baseline src tests [--no-exit-code]
 ```
 
 ## Usage

--- a/bin/phpcs-baseline
+++ b/bin/phpcs-baseline
@@ -1,0 +1,22 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// set default arguments next to src locations
+$_SERVER['argc']   += 3;
+$_SERVER['argv'][] = '--report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline';
+$_SERVER['argv'][] = '--report-file=phpcs.baseline.xml';
+$_SERVER['argv'][] = '--basepath=.';
+
+// invoke phpcs. find it next to this file or in vendor/bin
+foreach([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs'] as $path) {
+    if (file_exists($path)) {
+        require $path;
+        return;
+    }
+}
+
+// failed to find phpcs
+fwrite(STDERR, 'Could not find `vendor/bin/phpcs`. Make sure to run `composer require squizlabs/php_codesniffer`' . PHP_EOL);
+exit(1);

--- a/bin/phpcs-baseline
+++ b/bin/phpcs-baseline
@@ -10,7 +10,7 @@ $_SERVER['argv'][] = '--report-file=phpcs.baseline.xml';
 $_SERVER['argv'][] = '--basepath=.';
 
 // invoke phpcs. find it next to this file or in vendor/bin
-foreach([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs'] as $path) {
+foreach([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs',  __DIR__ . '/../../bin/phpcs'] as $path) {
     if (file_exists($path)) {
         require $path;
         return;

--- a/bin/phpcs-baseline
+++ b/bin/phpcs-baseline
@@ -9,10 +9,20 @@ $_SERVER['argv'][] = '--report=\\DR\\CodeSnifferBaseline\\Reports\\Baseline';
 $_SERVER['argv'][] = '--report-file=phpcs.baseline.xml';
 $_SERVER['argv'][] = '--basepath=.';
 
+// check for --no-exit-code argument
+foreach ($_SERVER['argv'] as $index => $argument) {
+    if ($argument === '--no-exit-code') {
+        unset($_SERVER['argv'][$index]);
+        register_shutdown_function(static fn() => exit(0));
+        break;
+    }
+}
+
 // invoke phpcs. find it next to this file or in vendor/bin
-foreach([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs',  __DIR__ . '/../../../bin/phpcs'] as $path) {
+foreach ([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs', __DIR__ . '/../../../bin/phpcs'] as $path) {
     if (file_exists($path)) {
         require $path;
+
         return;
     }
 }

--- a/bin/phpcs-baseline
+++ b/bin/phpcs-baseline
@@ -10,7 +10,7 @@ $_SERVER['argv'][] = '--report-file=phpcs.baseline.xml';
 $_SERVER['argv'][] = '--basepath=.';
 
 // invoke phpcs. find it next to this file or in vendor/bin
-foreach([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs',  __DIR__ . '/../../bin/phpcs'] as $path) {
+foreach([__DIR__ . '/phpcs', __DIR__ . '/../vendor/bin/phpcs',  __DIR__ . '/../../../bin/phpcs'] as $path) {
     if (file_exists($path)) {
         require $path;
         return;

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "scripts": {
         "baseline": ["@baseline:phpcs", "@baseline:phpmd", "@baseline:phpstan", "@baseline:phpcqc"],
-        "baseline:phpcs": "phpcs --report=\\\\DR\\\\CodeSnifferBaseline\\\\Reports\\\\Baseline --report-file=phpcs.baseline.xml --basepath=.",
+        "baseline:phpcs": "@php bin/phpcs-baseline src tests --no-exit-code",
         "baseline:phpmd": "@check:phpmd --generate-baseline",
         "baseline:phpstan": "phpstan --generate-baseline",
         "run:plugin": "DR\\CodeSnifferBaseline\\Plugin\\Plugin::run",

--- a/composer.json
+++ b/composer.json
@@ -57,5 +57,8 @@
             "DR\\CodeSnifferBaseline\\Tests\\Unit\\": "tests/Unit/",
             "DR\\CodeSnifferBaseline\\Tests\\": "tests/"
         }
-    }
+    },
+    "bin": [
+        "bin/phpcs-baseline"
+    ]
 }


### PR DESCRIPTION
Adds `vendor/bin/phpcs-baseline <path> [<path>]` as shorthand to run the baseline. 